### PR TITLE
Forward Chat Selection Popup

### DIFF
--- a/public/scss/chats.scss
+++ b/public/scss/chats.scss
@@ -131,3 +131,226 @@ body.page-user-chats {
 		display: none!important;
 	}
 }
+
+/* Forward Message Dropdown Styles */
+
+.forward-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 8px;
+    width: 280px;
+    max-height: 400px;
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1050;
+    display: none;
+    flex-direction: column;
+    overflow: hidden;
+
+    &.show {
+        display: flex;
+    }
+}
+
+
+.forward-dropdown-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--bs-border-color);
+    background: var(--bs-tertiary-bg);
+
+    .forward-dropdown-title {
+        font-weight: 600;
+        font-size: 14px;
+        color: var(--bs-body-color);
+    }
+
+    .close-forward-dropdown {
+        background: none;
+        border: none;
+        padding: 4px 8px;
+        cursor: pointer;
+        color: var(--bs-secondary-color);
+        transition: color 0.2s;
+
+        &:hover {
+            color: var(--bs-body-color);
+        }
+
+        i {
+            font-size: 14px;
+        }
+    }
+}
+
+// Search Container
+.forward-search-container {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--bs-border-color);
+
+    .forward-search-input {
+        width: 100%;
+        padding: 6px 12px;
+        font-size: 13px;
+        border-radius: 6px;
+
+        &:focus {
+            outline: none;
+            border-color: var(--bs-primary);
+            box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
+        }
+    }
+}
+
+.forward-recipients-list {
+    flex: 1;
+    overflow-y: auto;
+    max-height: 280px;
+
+    // Custom scrollbar
+    &::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: var(--bs-border-color);
+        border-radius: 3px;
+
+        &:hover {
+            background: var(--bs-secondary-color);
+        }
+    }
+}
+
+// Loading State
+.forward-loading {
+    display: none;
+    padding: 20px;
+    text-align: center;
+    color: var(--bs-secondary-color);
+
+    i {
+        margin-right: 8px;
+    }
+}
+
+// No Results State
+.forward-no-results {
+    display: none;
+    padding: 20px;
+    text-align: center;
+
+    p {
+        font-size: 13px;
+    }
+}
+
+.forward-recipient-item {
+    display: flex;
+    align-items: center;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    border-bottom: 1px solid var(--bs-border-color-translucent);
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    &:hover {
+        background-color: var(--bs-tertiary-bg);
+    }
+
+    &:active {
+        background-color: var(--bs-secondary-bg);
+    }
+}
+
+
+.forward-recipient-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    overflow: hidden;
+    margin-right: 12px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bs-secondary-bg);
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    i {
+        font-size: 18px;
+        color: var(--bs-secondary-color);
+    }
+}
+
+.forward-recipient-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.forward-recipient-name {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--bs-body-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.forward-recipient-status {
+    font-size: 12px;
+    color: var(--bs-secondary-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 2px;
+
+    i {
+        font-size: 11px;
+        margin-right: 4px;
+    }
+}
+
+
+.forward-dropdown-footer {
+    padding: 10px 16px;
+    border-top: 1px solid var(--bs-border-color);
+    background: var(--bs-tertiary-bg);
+    text-align: center;
+
+    small {
+        font-size: 12px;
+    }
+}
+
+// Position the dropdown relative to the message controls
+[component="chat/message"] {
+    position: relative;
+
+    .message-body-wrapper {
+        position: relative;
+
+        .controls {
+            position: relative;
+        }
+    }
+}

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -119,12 +119,16 @@ define('forum/chats', [
 		$('[data-action="close"]').on('click', function () {
 			Chats.switchChat();
 		});
+		console.log('Initializing user list for roomId:', roomId);
 		userList.init(roomId, mainWrapper);
 		Chats.addNotificationSettingHandler(roomId, mainWrapper);
 		messageSearch.init(roomId, mainWrapper);
 		Chats.addPublicRoomSortHandler();
 		Chats.addTooltipHandler(mainWrapper);
 		pinnedMessages.init(mainWrapper);
+
+		console.log('Initializing forward message dropdown');
+		messages.initForwardDropdown(); // Start the forward dropdown when hovering over message
 	};
 
 	Chats.addPublicRoomSortHandler = function () {
@@ -430,6 +434,7 @@ define('forum/chats', [
 			switch (action) {
 				case 'reply':
 					messages.prepReplyTo(msgEl, element);
+					
 					break;
 				case 'edit':
 					messages.prepEdit(msgEl, messageId, roomId);

--- a/public/src/client/chats/messages.js
+++ b/public/src/client/chats/messages.js
@@ -359,5 +359,279 @@ define('forum/chats/messages', [
 		}).catch(alerts.error);
 	};
 
+	/**
+	 * Initialize forward message dropdown
+	 */
+	messages.initForwardDropdown = function () {
+		console.log('Initializing forward message dropdown handlers');
+		$(document).off('click.forward').on('click.forward', '[component="chat/message/reply"]', function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			const msgEl = $(this).closest('[component="chat/message"]');
+			const mid = msgEl.attr('data-mid');
+			const roomId = msgEl.closest('[component="chat/messages"]').attr('data-roomid');
+			
+			// Close any other open dropdowns
+			$('.forward-dropdown').removeClass('show');
+			
+			// Toggle this dropdown
+			const dropdown = msgEl.find('.forward-dropdown');
+			if (dropdown.hasClass('show')) {
+				dropdown.removeClass('show');
+			} else {
+				messages.showForwardDropdown(mid, roomId, msgEl);
+			}
+		});
+
+		// Close dropdown when clicking outside
+		$(document).off('click.forward-outside').on('click.forward-outside', function (e) {
+			if (!$(e.target).closest('.forward-dropdown, [component="chat/message/reply"]').length) {
+				$('.forward-dropdown').removeClass('show');
+			}
+		});
+
+		// Close button handler
+		$(document).off('click.forward-close').on('click.forward-close', '.close-forward-dropdown', function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			$(this).closest('.forward-dropdown').removeClass('show');
+		});
+
+		// Show dropdown on message hover (with small delay to avoid flicker)
+		$(document).off('mouseenter.forward mouseleave.forward', '[component="chat/message"]').on('mouseenter.forward', '[component="chat/message"]', function () {
+			const msgEl = $(this);
+			// Clear any pending hide timer
+			clearTimeout(msgEl.data('forwardHideTimer'));
+			// If already shown, nothing to do
+			const dropdown = msgEl.find('.forward-dropdown');
+			if (dropdown.hasClass('show')) {
+				return;
+			}
+			// Set a short timer to open dropdown (prevents accidental triggers)
+			const openTimer = setTimeout(() => {
+				const mid = msgEl.attr('data-mid');
+				const roomId = msgEl.closest('[component="chat/messages"]').attr('data-roomid');
+				messages.showForwardDropdown(mid, roomId, msgEl);
+			}, 250);
+			msgEl.data('forwardOpenTimer', openTimer);
+		}).on('mouseleave.forward', '[component="chat/message"]', function () {
+			const msgEl = $(this);
+			// Cancel open timer if still pending
+			clearTimeout(msgEl.data('forwardOpenTimer'));
+			// Start hide timer so user can move into dropdown
+			const dropdown = msgEl.find('.forward-dropdown');
+			const hideTimer = setTimeout(() => {
+				dropdown.removeClass('show');
+			}, 300);
+			msgEl.data('forwardHideTimer', hideTimer);
+		});
+
+		// Keep dropdown open if hovered, hide when leaving dropdown
+		$(document).off('mouseenter.forwardDropdown mouseleave.forwardDropdown', '.forward-dropdown').on('mouseenter.forwardDropdown', '.forward-dropdown', function () {
+			const dropdown = $(this);
+			clearTimeout(dropdown.data('forwardHideTimer'));
+		}).on('mouseleave.forwardDropdown', '.forward-dropdown', function () {
+			const dropdown = $(this);
+			// hide shortly after leaving dropdown
+			const hideTimer = setTimeout(() => dropdown.removeClass('show'), 200);
+			dropdown.data('forwardHideTimer', hideTimer);
+		});
+	};
+
+	/**
+	 * Show forward dropdown and load available chats
+	 */
+	messages.showForwardDropdown = async function (mid, currentRoomId, msgEl) {
+		const dropdown = msgEl.find('.forward-dropdown');
+		dropdown.addClass('show');
+		
+		// Show loading state
+		dropdown.find('.forward-loading').show();
+		dropdown.find('.forward-recipients-container').empty();
+		dropdown.find('.forward-no-results').hide();
+
+		try {
+			// Fetch available rooms (excluding current room)
+			const rooms = await messages.fetchAvailableRooms(currentRoomId);
+			
+			dropdown.find('.forward-loading').hide();
+			
+			if (rooms.length === 0) {
+				dropdown.find('.forward-no-results').show();
+				return;
+			}
+
+			// Render rooms
+			messages.renderForwardRecipients(dropdown, rooms, mid, currentRoomId);
+			
+		} catch (err) {
+			dropdown.find('.forward-loading').hide();
+			alerts.error('Failed to load chats');
+			console.error(err);
+		}
+	};
+
+	/**
+	 * Fetch available rooms for forwarding
+	 */
+	messages.fetchAvailableRooms = async function (currentRoomId) {
+		try {
+			// Fetch rooms from API
+			const data = await api.get('/chats', { start: 0 });
+			
+			if (!data || !data.rooms) {
+				console.warn('No rooms returned from API');
+				return [];
+			}
+
+			// Filter out current room and map to our format
+			const recentRooms = data.rooms
+				.filter(room => parseInt(room.roomId, 10) !== parseInt(currentRoomId, 10))
+				.map(room => ({
+					roomId: room.roomId,
+					roomName: room.roomName || room.usernames,
+					teaser: room.teaser ? room.teaser.content : '',
+					avatar: room.teaser ? room.teaser.user.picture : null,
+				}));
+
+			// Also try to get public rooms if they exist
+			let publicRooms = [];
+			if (ajaxify.data.publicRooms && Array.isArray(ajaxify.data.publicRooms)) {
+				publicRooms = ajaxify.data.publicRooms
+					.filter(room => parseInt(room.roomId, 10) !== parseInt(currentRoomId, 10))
+					.map(room => ({
+						roomId: room.roomId,
+						roomName: room.roomName,
+						isPublic: true,
+						icon: room.icon || 'fa fa-comments',
+					}));
+			}
+
+			const allRooms = [...recentRooms, ...publicRooms];
+			console.log('Fetched rooms for forwarding:', allRooms);
+			return allRooms;
+
+		} catch (err) {
+			console.error('Error fetching rooms:', err);
+		}
+	};
+
+
+	/**
+	 * Render recipient list in dropdown
+	 */
+	messages.renderForwardRecipients = function (dropdown, rooms, mid, currentRoomId) {
+		const container = dropdown.find('.forward-recipients-container');
+		container.empty();
+
+		rooms.forEach(function (room) {
+			const recipientHtml = `
+				<div class="forward-recipient-item" data-roomid="${room.roomId}" data-mid="${mid}">
+					<div class="forward-recipient-avatar">
+						${room.avatar ? 
+								`<img src="${room.avatar}" alt="${room.roomName}">` : 
+								`<i class="${room.icon || 'fa fa-user'}"></i>`
+						}
+					</div>
+					<div class="forward-recipient-info">
+						<span class="forward-recipient-name">${room.roomName}</span>
+						${room.teaser ? `<span class="forward-recipient-status">${room.teaser}</span>` : ''}
+						${room.isPublic ? '<span class="forward-recipient-status"><i class="fa fa-globe"></i> Public</span>' : ''}
+					</div>
+				</div>
+			`;
+			container.append(recipientHtml);
+		});
+
+		// Add click handlers for recipients
+		container.find('.forward-recipient-item').off('click').on('click', function () {
+			const recipientEl = $(this);
+			const targetRoomId = recipientEl.attr('data-roomid');
+			const messageId = recipientEl.attr('data-mid');
+			
+			messages.forwardMessage(messageId, currentRoomId, targetRoomId);
+			dropdown.removeClass('show');
+		});
+
+		// Add search functionality
+		messages.initForwardSearch(dropdown, rooms, mid, currentRoomId);
+	};
+
+	/**
+	 * Initialize search functionality in forward dropdown
+	 */
+	messages.initForwardSearch = function (dropdown, rooms, mid, currentRoomId) {
+		const searchInput = dropdown.find('.forward-search-input');
+		
+		searchInput.off('input').on('input', function () {
+			const query = $(this).val().toLowerCase().trim();
+			
+			if (!query) {
+				// Show all rooms
+				messages.renderForwardRecipients(dropdown, rooms, mid, currentRoomId);
+				return;
+			}
+
+			// Filter rooms
+			const filteredRooms = rooms.filter(function (room) {
+				return room.roomName.toLowerCase().includes(query);
+			});
+
+			if (filteredRooms.length === 0) {
+				dropdown.find('.forward-recipients-container').empty();
+				dropdown.find('.forward-no-results').show();
+			} else {
+				dropdown.find('.forward-no-results').hide();
+				messages.renderForwardRecipients(dropdown, filteredRooms, mid, currentRoomId);
+			}
+		});
+	};
+
+	/**
+	 * Forward message to another room
+	 * Note: This is a placeholder - backend implementation will be needed
+	 */
+	messages.forwardMessage = async function (messageId, fromRoomId, toRoomId) {
+		try {
+			// Show loading indicator
+			alerts.alert({
+				alert_id: 'forwarding_message',
+				title: '[[modules:chat.forwarding]]',
+				message: '[[modules:chat.forwarding-message]]',
+				type: 'info',
+				timeout: 2000,
+			});
+
+			// TODO: Replace with actual API call when backend is ready
+			// For now, just show success message
+			// const response = await api.post(`/chats/${fromRoomId}/messages/${messageId}/forward`, {
+			//     toRoomId: toRoomId
+			// });
+
+			// Simulated success (remove this when backend is ready)
+			setTimeout(function () {
+				alerts.alert({
+					alert_id: 'message_forwarded',
+					title: '[[global:alert.success]]',
+					message: '[[modules:chat.message-forwarded]]',
+					type: 'success',
+					timeout: 3000,
+				});
+			}, 500);
+
+			hooks.fire('action:chat.forwarded', {
+				messageId: messageId,
+				fromRoomId: fromRoomId,
+				toRoomId: toRoomId,
+			});
+
+		} catch (err) {
+			alerts.error(err);
+			console.error('Forward error:', err);
+		}
+	};
+
 	return messages;
 });
+
+

--- a/src/views/partials/chats/message.tpl
+++ b/src/views/partials/chats/message.tpl
@@ -72,5 +72,41 @@
 				</div>
 			</div>
 		</div>
+
+		<!----------- Forward Message Dropdown ------------>
+		<div class="forward-dropdown" data-message-id="{messages.messageId}">
+			<div class="forward-dropdown-header">
+				<span class="forward-dropdown-title">Forward to:</span>
+				<button class="close-forward-dropdown" aria-label="Close">
+					<i class="fa fa-times"></i>
+				</button>
+			</div>
+			
+			<div class="forward-search-container">
+				<input type="text" 
+					class="form-control form-control-sm forward-search-input" 
+					placeholder="Search chats..."
+					autocomplete="off">
+			</div>
+			
+			<div class="forward-recipients-list">
+				<div class="forward-loading text-center py-3">
+					<i class="fa fa-spinner fa-spin"></i> Loading chats...
+				</div>
+				
+				<div class="forward-no-results text-center py-3">
+					<p class="text-muted mb-0">No chats found</p>
+				</div>
+				
+				<div class="forward-recipients-container">
+				</div>
+			</div>
+			
+			<div class="forward-dropdown-footer">
+				<small class="text-muted">Click a chat to forward</small>
+			</div>
+		</div>
+		<!-- End Forward Message Dropdown -->
+
 	</div>
 </li>


### PR DESCRIPTION
Summary:
Implements a searchable dropdown popup that allows users to forward chat messages to other conversations.

How it Works:
When a user hovers over a message, initForwardDropdown() is triggered, which displays a dropdown positioned below the message controls. The dropdown calls fetchAvailableRooms() to retrieve the user's chat list via NodeBB's /chats API endpoint, filtering out the current room. The fetched rooms are rendered as clickable items by renderForwardRecipients(), which also initializes real-time search functionality through initForwardSearch(). When the user types in the search box, the recipient list is filtered client-side for instant results. Clicking a recipient triggers forwardMessage(), which will send a POST request to the backend (currently simulated with a success notification). The feature integrates with NodeBB's existing modules (API, alerts, hooks) and follows the framework's initialization pattern by being called in Chats.addEventListeners().

How to Test:
Open any chat conversation
Hover over a message (triggers dropdown - temporary, will use Forward button)
Search for a chat name
Click a chat to forward (shows success message)

<img width="2058" height="1170" alt="Screenshot 2026-02-06 at 1 45 35 AM" src="https://github.com/user-attachments/assets/8b409627-cf12-45d3-b452-be1170af5ae8" />
