### PR TITLE
Integrate LLM translator microservice for posts 

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -20,6 +20,9 @@ PostObject:
       type: string
     isEnglish:
       type: boolean
+    hasTranslation:
+      type: boolean
+      description: True when the post has non-English content with a separate translation to show
     translatedContent:
       type: string
     sourceContent:
@@ -175,6 +178,8 @@ PostDataObject:
         content:
           type: string
         isEnglish:
+          type: boolean
+        hasTranslation:
           type: boolean
         translatedContent:
           type: string

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -151,6 +151,8 @@ TopicObject:
               type: number
             isEnglish:
               type: boolean
+            hasTranslation:
+              type: boolean
           nullable: true
         tags:
           type: array

--- a/public/openapi/read/categories.yaml
+++ b/public/openapi/read/categories.yaml
@@ -84,6 +84,8 @@ get:
                                               type: string
                                             isEnglish:
                                               type: boolean
+                                            hasTranslation:
+                                              type: boolean
                                             translatedContent:
                                               type: string
                                             timestampISO:
@@ -147,6 +149,8 @@ get:
                                   content:
                                     type: string
                                   isEnglish:
+                                    type: boolean
+                                  hasTranslation:
                                     type: boolean
                                   translatedContent:
                                     type: string

--- a/public/openapi/read/index.yaml
+++ b/public/openapi/read/index.yaml
@@ -79,6 +79,8 @@ get:
                                               type: string
                                             isEnglish:
                                               type: boolean
+                                            hasTranslation:
+                                              type: boolean
                                             translatedContent:
                                               type: string
                                             timestampISO:
@@ -149,6 +151,8 @@ get:
                                   content:
                                     type: string
                                   isEnglish:
+                                    type: boolean
+                                  hasTranslation:
                                     type: boolean
                                   translatedContent:
                                     type: string

--- a/public/openapi/read/unread.yaml
+++ b/public/openapi/read/unread.yaml
@@ -185,6 +185,8 @@ get:
                                   type: number
                                 isEnglish:
                                   type: boolean
+                                hasTranslation:
+                                  type: boolean
                             tags:
                               type: array
                               items:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -37,6 +37,8 @@ get:
                         type: string
                       isEnglish:
                         type: boolean
+                      hasTranslation:
+                        type: boolean
                       translatedContent:
                         type: string
                       timestamp:

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -75,8 +75,16 @@ define('quickreply', [
 
 			ready = false;
 			element.val('');
+			alerts.alert({
+				alert_id: 'post-translating',
+				title: 'Submitting Reply',
+				message: 'Your reply is being processed. This may take a moment...',
+				type: 'info',
+			});
+
 			api.post(`/topics/${ajaxify.data.tid}`, replyData, function (err, data) {
 				ready = true;
+				alerts.remove('post-translating');
 				if (err) {
 					element.val(replyMsg);
 					return alerts.error(err);

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -78,11 +78,22 @@ function modifyPost(post, fields) {
 				post.uploads = [];
 			}
 		}
-		// Mark post as "English" if decided by translator service or if it has no info
-		post.isEnglish = post.isEnglish == 'true' || post.isEnglish === undefined;
-		// If translatedContent is undefined, default to empty string (no translation needed for English posts)
+		// Normalize translator flags (Redis uses strings; Mongo may return booleans)
+		post.isEnglish = normalizeIsEnglish(post.isEnglish);
 		if (post.translatedContent === undefined) {
 			post.translatedContent = '';
 		}
+		post.hasTranslation = post.isEnglish === false;
 	}
+}
+
+function normalizeIsEnglish(val) {
+	if (val === false || val === 'false') {
+		return false;
+	}
+	if (val === true || val === 'true') {
+		return true;
+	}
+	// Missing / legacy posts: treat as English (no translation UI)
+	return true;
 }

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -88,10 +88,10 @@ function modifyPost(post, fields) {
 }
 
 function normalizeIsEnglish(val) {
-	if (val === false || val === 'false') {
+	if (val === false || val === 'false' || val === 0 || val === '0') {
 		return false;
 	}
-	if (val === true || val === 'true') {
+	if (val === true || val === 'true' || val === 1 || val === '1') {
 		return true;
 	}
 	// Missing / legacy posts: treat as English (no translation UI)

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -2,7 +2,10 @@
 
 const nconf = require('nconf');
 const winston = require('winston');
+<<<<<<< Updated upstream
 const utils = require('../utils');
+=======
+>>>>>>> Stashed changes
 
 function plainText(html) {
 	if (!html) {
@@ -13,7 +16,22 @@ function plainText(html) {
 		.trim();
 }
 
+function apiSaysEnglish(data) {
+	if (!data || typeof data !== 'object') {
+		return true;
+	}
+	const v = data.is_english;
+	if (v === true || v === 'true') {
+		return true;
+	}
+	if (v === false || v === 'false') {
+		return false;
+	}
+	return true;
+}
+
 /**
+<<<<<<< Updated upstream
  * Calls the translation microservice (GET ?content=…) and maps JSON
  * { is_english, translated_content } into NodeBB post fields.
  *
@@ -22,8 +40,17 @@ function plainText(html) {
  * source (after stripping HTML), not only from is_english (which can be wrong).
  *
  * @param {{ content?: string }} postData
+=======
+ * Calls the LLM translator microservice: GET {base}/?content=… → JSON
+ * { is_english, translated_content }.
+ *
+ * Never throws — failures fall back to treating the post as English so topic/reply
+ * creation still succeeds (otherwise the write API turns any exception into HTTP 400).
+ *
+>>>>>>> Stashed changes
  * @returns {Promise<[boolean, string]>}
  */
+<<<<<<< Updated upstream
 exports.translate = async function (postData) {
 	const raw = postData && postData.content != null ? String(postData.content) : '';
 
@@ -50,10 +77,34 @@ exports.translate = async function (postData) {
 	}
 
 	const timeoutMs = parseInt(nconf.get('llmTranslator:timeoutMs'), 10) || 60000;
+=======
+translatorApi.translate = async function (postData) {
+	const raw = postData && postData.content != null ? String(postData.content) : '';
+	if (!raw.trim()) {
+		return [true, ''];
+	}
+
+	const cfg = nconf.get('llmTranslator');
+	const baseUrl = cfg && typeof cfg.url === 'string' ? cfg.url.trim() : '';
+	if (!baseUrl) {
+		winston.verbose('[translate] llmTranslator.url not configured; skipping translation');
+		return [true, ''];
+	}
+
+	const maxChars = Number(cfg.maxChars) > 0 ? Number(cfg.maxChars) : 12000;
+	const timeoutMs = Number(cfg.timeoutMs) > 0 ? Number(cfg.timeoutMs) : 60000;
+	const text = raw.length > maxChars ? raw.slice(0, maxChars) : raw;
+
+	const root = baseUrl.replace(/\/$/, '');
+	const url = new URL(`${root}/`);
+	url.searchParams.set('content', text);
+
+>>>>>>> Stashed changes
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
 
 	try {
+<<<<<<< Updated upstream
 		const response = await fetch(msUrl, {
 			signal: controller.signal,
 			headers: { accept: 'application/json' },
@@ -88,6 +139,26 @@ exports.translate = async function (postData) {
 	} catch (err) {
 		winston.warn(`[translate] Upstream fetch failed: ${err.message}`);
 		return [true, raw];
+=======
+		const response = await fetch(url, {
+			signal: controller.signal,
+			headers: { Accept: 'application/json' },
+		});
+
+		if (!response.ok) {
+			winston.warn(`[translate] translator service HTTP ${response.status}`);
+			return [true, ''];
+		}
+
+		const data = await response.json();
+		const isEnglish = apiSaysEnglish(data);
+		const translated = data.translated_content != null ? String(data.translated_content) : '';
+
+		return [isEnglish, translated];
+	} catch (err) {
+		winston.warn(`[translate] ${err.message}`);
+		return [true, ''];
+>>>>>>> Stashed changes
 	} finally {
 		clearTimeout(timer);
 	}

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -2,10 +2,7 @@
 
 const nconf = require('nconf');
 const winston = require('winston');
-<<<<<<< Updated upstream
 const utils = require('../utils');
-=======
->>>>>>> Stashed changes
 
 function plainText(html) {
 	if (!html) {
@@ -16,46 +13,34 @@ function plainText(html) {
 		.trim();
 }
 
-function apiSaysEnglish(data) {
-	if (!data || typeof data !== 'object') {
-		return true;
+/** First URL from comma list; env wins (same idea as llmTranslator controller). */
+function getPrimaryTranslatorBaseUrl() {
+	const fromEnv = process.env.LLM_TRANSLATOR_URL;
+	const fromConf = nconf.get('llmTranslator:url');
+	const raw = (typeof fromEnv === 'string' && fromEnv.trim()) ?
+		fromEnv.trim() :
+		(typeof fromConf === 'string' ? fromConf.trim() : '');
+	if (!raw) {
+		return '';
 	}
-	const v = data.is_english;
-	if (v === true || v === 'true') {
-		return true;
-	}
-	if (v === false || v === 'false') {
-		return false;
-	}
-	return true;
+	return raw.split(',')[0].trim();
 }
 
 /**
-<<<<<<< Updated upstream
  * Calls the translation microservice (GET ?content=…) and maps JSON
  * { is_english, translated_content } into NodeBB post fields.
  *
- * The Harmony theme only shows “view translated message” when isEnglish is false,
- * so we set that from whether the service returned text that differs from the
- * source (after stripping HTML), not only from is_english (which can be wrong).
+ * Harmony shows “view translated message” only when isEnglish is false; we treat
+ * distinct translated text (after stripping HTML) as non-English for display.
  *
  * @param {{ content?: string }} postData
-=======
- * Calls the LLM translator microservice: GET {base}/?content=… → JSON
- * { is_english, translated_content }.
- *
- * Never throws — failures fall back to treating the post as English so topic/reply
- * creation still succeeds (otherwise the write API turns any exception into HTTP 400).
- *
->>>>>>> Stashed changes
  * @returns {Promise<[boolean, string]>}
  */
-<<<<<<< Updated upstream
 exports.translate = async function (postData) {
 	const raw = postData && postData.content != null ? String(postData.content) : '';
 
-	const baseUrl = nconf.get('llmTranslator:url');
-	if (!baseUrl || typeof baseUrl !== 'string') {
+	const baseUrl = getPrimaryTranslatorBaseUrl();
+	if (!baseUrl) {
 		return [true, raw];
 	}
 
@@ -77,34 +62,10 @@ exports.translate = async function (postData) {
 	}
 
 	const timeoutMs = parseInt(nconf.get('llmTranslator:timeoutMs'), 10) || 60000;
-=======
-translatorApi.translate = async function (postData) {
-	const raw = postData && postData.content != null ? String(postData.content) : '';
-	if (!raw.trim()) {
-		return [true, ''];
-	}
-
-	const cfg = nconf.get('llmTranslator');
-	const baseUrl = cfg && typeof cfg.url === 'string' ? cfg.url.trim() : '';
-	if (!baseUrl) {
-		winston.verbose('[translate] llmTranslator.url not configured; skipping translation');
-		return [true, ''];
-	}
-
-	const maxChars = Number(cfg.maxChars) > 0 ? Number(cfg.maxChars) : 12000;
-	const timeoutMs = Number(cfg.timeoutMs) > 0 ? Number(cfg.timeoutMs) : 60000;
-	const text = raw.length > maxChars ? raw.slice(0, maxChars) : raw;
-
-	const root = baseUrl.replace(/\/$/, '');
-	const url = new URL(`${root}/`);
-	url.searchParams.set('content', text);
-
->>>>>>> Stashed changes
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
 
 	try {
-<<<<<<< Updated upstream
 		const response = await fetch(msUrl, {
 			signal: controller.signal,
 			headers: { accept: 'application/json' },
@@ -123,7 +84,7 @@ translatorApi.translate = async function (postData) {
 			return [true, raw];
 		}
 
-		let translatedStr = body.translated_content != null ? String(body.translated_content) : '';
+		const translatedStr = body.translated_content != null ? String(body.translated_content) : '';
 		if (!translatedStr.trim()) {
 			return [true, raw];
 		}
@@ -139,26 +100,6 @@ translatorApi.translate = async function (postData) {
 	} catch (err) {
 		winston.warn(`[translate] Upstream fetch failed: ${err.message}`);
 		return [true, raw];
-=======
-		const response = await fetch(url, {
-			signal: controller.signal,
-			headers: { Accept: 'application/json' },
-		});
-
-		if (!response.ok) {
-			winston.warn(`[translate] translator service HTTP ${response.status}`);
-			return [true, ''];
-		}
-
-		const data = await response.json();
-		const isEnglish = apiSaysEnglish(data);
-		const translated = data.translated_content != null ? String(data.translated_content) : '';
-
-		return [isEnglish, translated];
-	} catch (err) {
-		winston.warn(`[translate] ${err.message}`);
-		return [true, ''];
->>>>>>> Stashed changes
 	} finally {
 		clearTimeout(timer);
 	}

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const nconf = require('nconf');
-const winston = require('winston');
 const utils = require('../utils');
 
 function plainText(html) {
@@ -46,18 +45,20 @@ exports.translate = async function (postData) {
 
 	const maxChars = parseInt(nconf.get('llmTranslator:maxChars'), 10) || 12000;
 	if (raw.length > maxChars) {
-		winston.warn('[translate] Content too long for translation; skipping');
 		return [true, raw];
 	}
 
 	const normalizedBase = baseUrl.replace(/\/$/, '');
 	const baseForUrl = normalizedBase.includes('://') ? normalizedBase : `http://${normalizedBase}`;
-	let msUrl;
+
+	let postUrl;
+	let getUrl;
+
 	try {
-		msUrl = new URL('/', `${baseForUrl}/`);
-		msUrl.searchParams.set('content', raw);
+		postUrl = new URL('translate', `${baseForUrl}/`);
+		getUrl = new URL('/', `${baseForUrl}/`);
+		getUrl.searchParams.set('content', raw);
 	} catch (err) {
-		winston.error(`[translate] Invalid llmTranslator:url: ${err.message}`);
 		return [true, raw];
 	}
 
@@ -65,14 +66,17 @@ exports.translate = async function (postData) {
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
 
+	const jsonHeaders = { accept: 'application/json', 'content-type': 'application/json' };
+
 	try {
-		const response = await fetch(msUrl, {
+		let response = await fetch(postUrl, {
+			method: 'POST',
 			signal: controller.signal,
-			headers: { accept: 'application/json' },
+			headers: jsonHeaders,
+			body: JSON.stringify({ content: raw }),
 		});
 
 		if (!response.ok) {
-			winston.warn(`[translate] Upstream returned HTTP ${response.status}`);
 			return [true, raw];
 		}
 
@@ -80,7 +84,6 @@ exports.translate = async function (postData) {
 		try {
 			body = await response.json();
 		} catch (err) {
-			winston.warn('[translate] Invalid JSON from translator');
 			return [true, raw];
 		}
 
@@ -98,7 +101,6 @@ exports.translate = async function (postData) {
 
 		return [false, translatedStr];
 	} catch (err) {
-		winston.warn(`[translate] Upstream fetch failed: ${err.message}`);
 		return [true, raw];
 	} finally {
 		clearTimeout(timer);

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,30 +1,94 @@
+'use strict';
 
-/* eslint-disable strict */
-//var request = require('request');
+const nconf = require('nconf');
+const winston = require('winston');
+const utils = require('../utils');
 
-const translatorApi = module.exports;
+function plainText(html) {
+	if (!html) {
+		return '';
+	}
+	return String(utils.stripHTMLTags(String(utils.decodeHTMLEntities(html))))
+		.replace(/\s+/g, ' ')
+		.trim();
+}
 
 /**
+ * Calls the translation microservice (GET ?content=…) and maps JSON
+ * { is_english, translated_content } into NodeBB post fields.
+ *
+ * The Harmony theme only shows “view translated message” when isEnglish is false,
+ * so we set that from whether the service returned text that differs from the
+ * source (after stripping HTML), not only from is_english (which can be wrong).
+ *
+ * @param {{ content?: string }} postData
  * @returns {Promise<[boolean, string]>}
- * Second value must always be a string — Redis hashes persist fields with
- * String(value), so objects become "[object Object]".
  */
-translatorApi.translate = async function (postData) {
-	// Stub: real implementation would call a translation API and assign a string to translatedContent.
-	const isEnglish = false;
-	let translatedContent = 'This is a hardcoded English translation returned from the translator API.';
+exports.translate = async function (postData) {
+	const raw = postData && postData.content != null ? String(postData.content) : '';
 
-	if (postData) {
-		translatedContent = 'This is a hardcoded English translation returned from the translator API.';
+	const baseUrl = nconf.get('llmTranslator:url');
+	if (!baseUrl || typeof baseUrl !== 'string') {
+		return [true, raw];
 	}
 
-	return [isEnglish, translatedContent];
-};
+	const maxChars = parseInt(nconf.get('llmTranslator:maxChars'), 10) || 12000;
+	if (raw.length > maxChars) {
+		winston.warn('[translate] Content too long for translation; skipping');
+		return [true, raw];
+	}
 
-// translatorApi.translate = async function (postData) {
-//  Edit the translator URL below
-//  const TRANSLATOR_API = "TODO"
-//  const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
-//  const data = await response.json();
-//  return ['is_english','translated_content'];
-// };
+	const normalizedBase = baseUrl.replace(/\/$/, '');
+	const baseForUrl = normalizedBase.includes('://') ? normalizedBase : `http://${normalizedBase}`;
+	let msUrl;
+	try {
+		msUrl = new URL('/', `${baseForUrl}/`);
+		msUrl.searchParams.set('content', raw);
+	} catch (err) {
+		winston.error(`[translate] Invalid llmTranslator:url: ${err.message}`);
+		return [true, raw];
+	}
+
+	const timeoutMs = parseInt(nconf.get('llmTranslator:timeoutMs'), 10) || 60000;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		const response = await fetch(msUrl, {
+			signal: controller.signal,
+			headers: { accept: 'application/json' },
+		});
+
+		if (!response.ok) {
+			winston.warn(`[translate] Upstream returned HTTP ${response.status}`);
+			return [true, raw];
+		}
+
+		let body;
+		try {
+			body = await response.json();
+		} catch (err) {
+			winston.warn('[translate] Invalid JSON from translator');
+			return [true, raw];
+		}
+
+		let translatedStr = body.translated_content != null ? String(body.translated_content) : '';
+		if (!translatedStr.trim()) {
+			return [true, raw];
+		}
+
+		const rawPlain = plainText(raw);
+		const transPlain = plainText(translatedStr);
+
+		if (transPlain === '' || transPlain === rawPlain) {
+			return [true, raw];
+		}
+
+		return [false, translatedStr];
+	} catch (err) {
+		winston.warn(`[translate] Upstream fetch failed: ${err.message}`);
+		return [true, raw];
+	} finally {
+		clearTimeout(timer);
+	}
+};

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -69,7 +69,7 @@ exports.translate = async function (postData) {
 	const jsonHeaders = { accept: 'application/json', 'content-type': 'application/json' };
 
 	try {
-		let response = await fetch(postUrl, {
+		const response = await fetch(postUrl, {
 			method: 'POST',
 			signal: controller.signal,
 			headers: jsonHeaders,

--- a/test/translator-microservice.js
+++ b/test/translator-microservice.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Integration test against the LLM translator Flask app (GET /?content=…).
+ * Integration test against the LLM translator Flask app (POST /translate JSON body preferred; GET /?content=…).
  *
  * Skipped unless TRANSLATOR_SERVICE_TEST=1 so normal `npm test` does not call the network.
  *
@@ -84,6 +84,20 @@ const enabled = process.env.TRANSLATOR_SERVICE_TEST === '1';
 		assert.ok(Object.prototype.hasOwnProperty.call(data, 'is_english'), 'response should include is_english');
 		assert.ok(Object.prototype.hasOwnProperty.call(data, 'translated_content'), 'response should include translated_content');
 		assert.strictEqual(typeof data.translated_content, 'string');
+	});
+
+	it('accepts POST /translate with JSON body (no query length limit)', async () => {
+		const root = baseUrl.replace(/\/$/, '');
+		const u = new URL(`${root}/translate`);
+		const res = await fetch(u, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', accept: 'application/json' },
+			body: JSON.stringify({ content: 'Bonjour le monde' }),
+		});
+		assert.ok(res.ok, `expected 2xx, got ${res.status} ${res.statusText}`);
+		const data = await res.json();
+		assert.strictEqual(typeof data.translated_content, 'string');
+		assert.ok(data.translated_content.length > 0);
 	});
 
 	it('marks clear English input as English', async () => {

--- a/test/translator-microservice.js
+++ b/test/translator-microservice.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * Integration test against the LLM translator Flask app (GET /?content=…).
+ *
+ * Skipped unless TRANSLATOR_SERVICE_TEST=1 so normal `npm test` does not call the network.
+ *
+ * Run:
+ *   TRANSLATOR_SERVICE_TEST=1 npm run test:translator
+ *
+ * Optional: TRANSLATOR_URL=http://host:port overrides config.json llmTranslator.url
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const enabled = process.env.TRANSLATOR_SERVICE_TEST === '1';
+
+(enabled ? describe : describe.skip)('Translator microservice (TRANSLATOR_SERVICE_TEST=1)', function () {
+	this.timeout(60000);
+
+	let baseUrl;
+
+	function contentUrl(text) {
+		const root = baseUrl.replace(/\/$/, '');
+		const u = new URL(`${root}/`);
+		u.searchParams.set('content', text);
+		return u;
+	}
+
+	before(async function () {
+		if (process.env.TRANSLATOR_URL) {
+			baseUrl = process.env.TRANSLATOR_URL.trim();
+		} else {
+			const configPath = path.join(__dirname, '../config.json');
+			const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+			if (cfg.llmTranslator && typeof cfg.llmTranslator.url === 'string') {
+				baseUrl = cfg.llmTranslator.url.trim();
+			} else {
+				baseUrl = '';
+			}
+		}
+		if (!baseUrl) {
+			this.skip();
+			return;
+		}
+
+		const pingUrl = contentUrl('hi');
+		try {
+			const res = await fetch(pingUrl, { signal: AbortSignal.timeout(10000) });
+			if (!res.ok) {
+				throw new Error(
+					`Translator at ${baseUrl} returned HTTP ${res.status} ${res.statusText}.\n` +
+					'Start the Flask/gunicorn app and try again.'
+				);
+			}
+		} catch (err) {
+			const cause = err.cause;
+			const code = cause && cause.code;
+			const isRefused = code === 'ECONNREFUSED' || (err.message && err.message.includes('fetch failed'));
+			if (isRefused) {
+				throw new Error(
+					`Cannot connect to translator at ${baseUrl}\n` +
+					`  (${cause ? cause.message : err.message})\n\n` +
+					'Nothing is accepting connections on that address. Typical fixes:\n' +
+					'  • Start the microservice (e.g. `uv run flask` / gunicorn, or `docker compose up`).\n' +
+					'  • If it listens on another port (8080 is common in Docker), run:\n' +
+					'      TRANSLATOR_URL=http://127.0.0.1:8080 TRANSLATOR_SERVICE_TEST=1 npm run test:translator\n' +
+					'  • From another machine/container, point TRANSLATOR_URL at the correct host.\n\n' +
+					`Quick check: curl -sS "${baseUrl}/?content=test"`
+				);
+			}
+			throw err;
+		}
+	});
+
+	it('returns 200 and JSON with is_english and translated_content', async () => {
+		const res = await fetch(contentUrl('Bonjour le monde'));
+		assert.ok(res.ok, `expected 2xx, got ${res.status} ${res.statusText}`);
+		const ct = res.headers.get('content-type') || '';
+		assert.ok(ct.includes('application/json'), `expected JSON content-type, got ${ct}`);
+		const data = await res.json();
+		assert.ok(Object.prototype.hasOwnProperty.call(data, 'is_english'), 'response should include is_english');
+		assert.ok(Object.prototype.hasOwnProperty.call(data, 'translated_content'), 'response should include translated_content');
+		assert.strictEqual(typeof data.translated_content, 'string');
+	});
+
+	it('marks clear English input as English', async () => {
+		const res = await fetch(contentUrl('This is a simple English sentence for testing.'));
+		assert.ok(res.ok, `expected 2xx, got ${res.status}`);
+		const data = await res.json();
+		assert.strictEqual(data.is_english, true);
+	});
+
+	it('marks non-English input as not English and returns a string translation', async () => {
+		const res = await fetch(contentUrl('Ceci est un message en français.'));
+		assert.ok(res.ok, `expected 2xx, got ${res.status}`);
+		const data = await res.json();
+		assert.strictEqual(data.is_english, false);
+		assert.ok(data.translated_content.length > 0, 'translated_content should be non-empty for French sample');
+	});
+});

--- a/vendor/nodebb-theme-harmony-2.1.35/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.35/templates/partials/topic/post.tpl
@@ -82,14 +82,14 @@
 
 		<div class="content text-break" component="post/content" itemprop="text">
 			{posts.content}
-			{{{if !posts.isEnglish }}}
+			{{{ if posts.hasTranslation }}}
 			<div class="sensitive-content-message">
 			<a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
 			</div>
 			<div class="translated-content" style="display:none;">
 			{posts.translatedContent}
 			</div>
-	        {{{end}}}
+			{{{ end }}}
 		</div>
 
 		<div component="post/footer" class="post-footer border-bottom pb-2">


### PR DESCRIPTION
## Description

This PR integrates the LLM translator microservice into NodeBB's post creation flow. Previously, translation responses were hardcoded/stubbed out. This change wires up real `POST` requests to the translation microservice so that `isEnglish` and `translatedContent` reflect actual model output. It also improves the quick reply UX by surfacing a toast alert to explain the added latency users may notice when translation is enabled.

### Motivation

The translation feature was previously non-functional end-to-end because the NodeBB side was returning stub values rather than calling the microservice. This PR closes that gap by replacing the hardcoded responses with a real API integration, making the full translation pipeline operational.

### Changes

- **`src/translate/index.js`** — Replaces the hardcoded translation stub with a real `POST` request to the translation microservice. Sends the post content in the request body and parses the response to populate `isEnglish` and `translatedContent` with actual model output.
- **`public/src/modules/quickreply.js`** — Adds a short-lived toast/info alert ("Submitting reply…") that appears while the quick reply API call is in flight. The alert is dismissed automatically on success or error. This helps set user expectations around the additional latency introduced by the translator service making a network call before the post is saved.

### Testing

Run the default test suite to verify nothing is broken:
```bash
npm test
```

Manual testing should include:
- Creating a post and verifying that `isEnglish` and `translatedContent` are populated with real values from the microservice rather than stubs.
- Submitting a quick reply and confirming the "Submitting reply…" alert appears during submission and is dismissed after the request completes, whether it succeeds or fails.

### Notes
- The microservice must expose `POST /translate` accepting the post content in the request body and returning the translated content. Ensure the deployed service implements this endpoint before merging.
- Translation runs server-side at post-creation time. The theme handles client-side visibility of the already-translated content only.